### PR TITLE
docs: fix PersonalD typo

### DIFF
--- a/docs/05 - LSAPerson.md
+++ b/docs/05 - LSAPerson.md
@@ -668,7 +668,7 @@ flowchart LR
 
 | **ch_Exclude** | **Column Description** |
 |----|----|
-| **PersonalID** | **PersonalD** |
+| **PersonalID** | **PersonalID** |
 | **ExcludeDate** | Distinct dates between **CHStart** and **LastActive** when client was either in TH or housed in RRH/PSH. |
 
 ## Logic
@@ -736,7 +736,7 @@ flowchart LR
 
 | **ch_Include** | **Column Description** |
 |----|----|
-| **PersonalID** | **PersonalD** |
+| **PersonalID** | **PersonalID** |
 | **ESSHStreetDate** | Distinct dates between **CHStart** and **LastActive** when client was in ES/SH or on the street; also referred to as ES/SH/Street dates. |
 
 ## Logic
@@ -1388,5 +1388,4 @@ As noted, tlsa\_Person is a client-level precursor to lsa\_Person / LSAPerson.cs
 **RowTotal** is a count of **PersonalID**s in tlsa\_Person, grouped by all of the other columns in LSAPerson.
 
 See [LSA Data Dictionary - Files and Columns](LSA Data Dictionary - Columns.md#3---lsaperson) for file specifications.  
-
 

--- a/docs/07 - LSAExit.md
+++ b/docs/07 - LSAExit.md
@@ -441,7 +441,7 @@ flowchart LR
 
 | **ch_Exclude_exit** | **Column Description**                                                                                                              |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| PersonalID      | **PersonalD**                                                                                                                       |
+| PersonalID      | **PersonalID**                                                                                                                      |
 | ExcludeDate     | Distinct dates between a person’s earliest **CHStart** and latest **LastActive** when client was either in TH or housed in RRH/PSH. |
 
 ## Logic
@@ -514,7 +514,7 @@ flowchart LR
 
 | **ch_Include_exit** | **Column Description**                                                                                                                                   |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PersonalID      | **PersonalD**                                                                                                                                            |
+| PersonalID      | **PersonalID**                                                                                                                                           |
 | ESSHStreetDate  | Distinct dates between earliest **CHStart** and latest **LastActive** when client was in ES/SH or on the street; also referred to as ES/SH/Street dates. |
 
 ## Logic


### PR DESCRIPTION
Closes #1466

## Summary

Fixes the `PersonalD` typo to `PersonalID` in four table cells:

- `docs/05 - LSAPerson.md`: ch_Exclude and ch_Include column descriptions
- `docs/07 - LSAExit.md`: ch_Exclude_exit and ch_Include_exit column descriptions

Docs-only change.

Signed off with DCO.
